### PR TITLE
chore: update baseURL in config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'http://example.org/'
+baseURL = 'https://gnistor.se/'
 languageCode = 'sv-SE'
 defaultContentLanguage = 'sv'
 defaultContentLang = 'sv'


### PR DESCRIPTION
This shouldn't do anything, it's overridden in the GH build pipeline anyway with `--baseUrl`, I just thought it looked ugly :) And might prevent future issues.