### PR TITLE
Fix sidebar: only show events from current year

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -35,17 +35,20 @@
 						{{ $enddate := (time .Params.enddate) }}
 						{{ if 
 						(and
-							(and 
-								(or 
-									(gt $enddate.Day $nowdate)
-									(eq $enddate.Day $nowdate)
+							(and
+								(and
+									(or
+										(gt $enddate.Day $nowdate)
+										(eq $enddate.Day $nowdate)
+									)
+									(or
+										(gt $nowdate .Date.Day)
+										(eq $nowdate .Date.Day)
+									)
 								)
-								(or
-									(gt $nowdate .Date.Day)
-									(eq $nowdate .Date.Day)
-								)
+								(eq .Date.Month $last_day_this_month.Month)
 							)
-							(eq .Date.Month $last_day_this_month.Month)
+							(eq .Date.Year now.Year)
 						)
 						}}
 							{{ $scratch.SetInMap $mapName .Permalink .Title }}
@@ -55,6 +58,7 @@
 							(and
 								(eq .Date.Day $nowdate)
 								(eq .Date.Month $last_day_this_month.Month)
+								(eq .Date.Year now.Year)
 							)
 						}}
 							{{ $scratch.SetInMap $mapName .Permalink .Title }}


### PR DESCRIPTION
Fix issue where the sidebar calendar was showing events from all years.

**Before:**
<img width="477" alt="Screenshot 2023-10-03 at 08 35 00" src="https://github.com/gnistor-se/gnistor/assets/9592259/7e0e451b-61ac-40d9-8c4e-ea8f64baead4">

**After:**
<img width="374" alt="Screenshot 2023-10-03 at 08 35 08" src="https://github.com/gnistor-se/gnistor/assets/9592259/77fc6788-ccd0-4e66-a7ca-e4cf3aff0d0f">
