### PR TITLE
fix: populate all fields in event archetype

### DIFF
--- a/archetypes/event.md
+++ b/archetypes/event.md
@@ -1,8 +1,14 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
-place: ""
+enddate: {{ .Date }}
 locations: []
 forms: []
 organizer: ""
+streetAddress: ""
+postalCode: ""
+addressName: ""
+addressRegion: ""
+addressCountry: ""
+source: ""
 ---


### PR DESCRIPTION
- Since there is a few more parameters being used, let's add them to the `event` archetype.
- Drop the `place` parameter, since it seems to be unused.
