### PR TITLE
fix: don't show range for range within same day

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -18,7 +18,7 @@
 			{{ if ( eq .Type "event" ) }}
 				<div class="flex flex-row gap-5 md:gap-7 justify-evenly my-9">
 					<div class="bg-opace flex-none w-14 md:w-16 rounded-2xl flex flex-col justify-center items-center">
-						{{ if isset .Params "enddate" }}
+						{{ if and (.Params.enddate) (ne (time .Params.enddate).Day .Date.Day) }}
 							{{ $enddate := (time .Params.enddate) }}
 							<div>
 								<h3 class="tracking-tighter font-bold text-sm m-0">{{ .Date.Day }}-{{ $enddate.Day }}</h3>
@@ -36,7 +36,7 @@
 					<div class="flex-auto overflow-hidden text-sm">
 						<p class="my-1 text-slate-500 truncate">
 							<time datetime="{{ dateFormat "2006-01-02T03:04PM" .Date }}">
-							{{ if .Params.enddate}}
+							{{ if and (.Params.enddate) (ne (time .Params.enddate).Day .Date.Day) }}
 								{{ $enddate := (time .Params.enddate) }}
 								{{ dateFormat "2 January" .Date }}
 								– {{ dateFormat "2 January"  $enddate }}


### PR DESCRIPTION
Fix for the issue where a range is displayed, when the start date and enddate is the same day. 

See picture: 
<img width="99" alt="Screenshot 2024-02-21 at 18 12 02" src="https://github.com/gnistor-se/gnistor/assets/9592259/f4ab5185-1efe-4604-a289-d87d5b3e8e80">
