### PR TITLE
Removing html encoding from summary and organizer fields in the ics

### DIFF
--- a/layouts/index.ics
+++ b/layouts/index.ics
@@ -6,8 +6,8 @@ METHOD:PUBLISH
 {{ range where .Site.RegularPages.ByDate "Type" "event"}}{{ if (time .Params.date).After (now.AddDate 0 -1 0) }}
 BEGIN:VEVENT
 UID:{{ .File.Filename }}
-ORGANIZER;CN={{ .Params.organizer }}:mailto:hej@gnistor.se
-SUMMARY:{{.Params.title}}
+ORGANIZER;CN={{ htmlUnescape .Params.organizer | safeHTML }}:mailto:hej@gnistor.se
+SUMMARY:{{ htmlUnescape .Params.title | safeHTML }}
 SEQUENCE:0
 STATUS:CONFIRMED
 DTSTAMP:{{dateFormat "20060102T150405Z" .Date}}


### PR DESCRIPTION
This resolves issue gnistor-se/gnistor#42

Har testat och detta löser problemet i calcurse och jag får inte ett problem om jag läser in filen i ICSx5, har inte testat att prenumerera på ics-länken mot sidan.